### PR TITLE
Switch from the shell version to the exec version of ENTRYPOINT.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG SIA_DATA_DIR="/sia-data"
 COPY --from=zip_downloader /sia/siac "${SIA_DIR}/siac"
 COPY --from=zip_downloader /sia/siad "${SIA_DIR}/siad"
 
-RUN apt-get update && apt-get install -y socat
+RUN apt-get update && apt-get install -y --no-install-recommends socat
 
 # Workaround for backwards compatibility with old images, which hardcoded the
 # Sia data directory as /mnt/sia. Creates a symbolic link so that any previous
@@ -35,8 +35,6 @@ WORKDIR "$SIA_DIR"
 ENV SIA_DATA_DIR "$SIA_DATA_DIR"
 ENV SIA_MODULES gctwhr
 
-ENTRYPOINT socat tcp-listen:9980,reuseaddr,fork tcp:localhost:8000 & \
-  ./siad \
-    --modules "$SIA_MODULES" \
-    --sia-directory "$SIA_DATA_DIR" \
-    --api-addr "localhost:8000"
+COPY run.sh ./
+
+ENTRYPOINT ["./run.sh"]

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -21,6 +21,6 @@ RUN apk --no-cache add socat
 WORKDIR "$SIA_DIR"
 COPY --from=builder /go/bin/siad ./
 COPY --from=builder go/bin/siac ./
-COPY ../run.sh ./
+COPY run.sh ./
 
 ENTRYPOINT ["./run.sh"]

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -21,8 +21,6 @@ RUN apk --no-cache add socat
 WORKDIR "$SIA_DIR"
 COPY --from=builder /go/bin/siad ./
 COPY --from=builder go/bin/siac ./
-ENTRYPOINT socat tcp-listen:9980,reuseaddr,fork tcp:localhost:8000 & \
-  ./siad \
-    --modules "$SIA_MODULES" \
-    --sia-directory "$SIA_DATA_DIR" \
-    --api-addr "localhost:8000"
+COPY ../run.sh ./
+
+ENTRYPOINT ["./run.sh"]

--- a/dev/run.sh
+++ b/dev/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+socat tcp-listen:9980,reuseaddr,fork tcp:localhost:8000 &
+
+SIAD_CMD=$(cat <<-END
+./siad \
+  --modules $SIA_MODULES \
+  --sia-directory $SIA_DATA_DIR \
+  --api-addr localhost:8000
+END
+)
+
+# We are using `exec` to start `siad` in order to ensure that it will be run as
+# PID 1. We need that in order to have `siad` receive OS signals (e.g. SIGTERM)
+# on container shutdown, so it can exit gracefully and no data corruption can
+# occur.
+exec $SIAD_CMD

--- a/dev/run.sh
+++ b/dev/run.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 socat tcp-listen:9980,reuseaddr,fork tcp:localhost:8000 &
 
+# Use the `cat` utility in order assign a multi-line string to a variable.
 SIAD_CMD=$(cat <<-END
 ./siad \
   --modules $SIA_MODULES \

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+socat tcp-listen:9980,reuseaddr,fork tcp:localhost:8000 &
+
+SIAD_CMD=$(cat <<-END
+./siad \
+  --modules $SIA_MODULES \
+  --sia-directory $SIA_DATA_DIR \
+  --api-addr localhost:8000
+END
+)
+
+# We are using `exec` to start `siad` in order to ensure that it will be run as
+# PID 1. We need that in order to have `siad` receive OS signals (e.g. SIGTERM)
+# on container shutdown, so it can exit gracefully and no data corruption can
+# occur.
+exec $SIAD_CMD

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 socat tcp-listen:9980,reuseaddr,fork tcp:localhost:8000 &
 
+# Use the `cat` utility in order assign a multi-line string to a variable.
 SIAD_CMD=$(cat <<-END
 ./siad \
   --modules $SIA_MODULES \


### PR DESCRIPTION
This PR switches from using the shell version of ENTRYPOINT to the exec version.

The difference between the two versions is that in the shell one the executed command is run within an instance of `/bin/sh` which holds `PID 1`. The problem is that when the container is stopped `/bin/sh` receives the `SIGTERM` signal but doesn't send it to its children. This prevents `siad` from performing a graceful shutdown and exposes the user to a risk of data corruption. This chances of data corruption occurring is small since all disk operations performed by `siad` should be ACID. Nevertheless, nothing should stop us from eliminating it completely.

Closes #6 