### PR TITLE
Add a HEALTHCHECK and an "autoheal" LABEL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker run \
 
 **Important**: Never publish port 9980 to all interfaces. This is a security-sensitive API, so only expose it beyond 127.0.0.1 if you know what you're doing.
 
-Once the container is running, you can execute siac from within the container:
+Once the container is running, you can execute `siac` from within the container:
 
 ```bash
 $ docker exec -it sia-container ./siac consensus
@@ -32,11 +32,27 @@ Height: 3800
 Progress (estimated): 2.4%
 ```
 
-You can also call siad from outside the container:
+You can also call `siad` from outside the container:
 
 ```bash
 $ curl -A "Sia-Agent" "http://localhost:9980/consensus"
 {"synced":false,"height":4690,"currentblock":"0000000000007d656e3bb0099737892b9073259cb05883b04c6f518fbf0faffb","target":[0,0,0,0,0,2,200,179,126,85,220,153,25,190,195,228,72,53,129,181,62,124,175,60,255,90,105,68,179,16,6,71],"difficulty":"101104922300609"}
+```
+
+## Health monitoring
+
+The `sia` container is equipped with a [HEALTHCHECK](https://docs.docker.com/engine/reference/builder/#healthcheck) 
+and is labelled as `autoheal=true`. This allows us to use Will Farrel's [autoheal](https://hub.docker.com/r/willfarrell/autoheal/) 
+container in order to restart the `sia` container if it becomes unhealthy.
+
+All you need to do is start the `autoheal` container alongside `sia`:
+```
+docker run -d \
+    --name autoheal \
+    --restart=always \
+    -e AUTOHEAL_CONTAINER_LABEL=all \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    willfarrell/autoheal
 ```
 
 ## More examples

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -11,7 +11,6 @@ RUN go get -d -u gitlab.com/NebulousLabs/Sia/... && \
 
 FROM alpine
 LABEL maintainer="NebulousLabs <developers@nebulous.tech>"
-LABEL autoheal=true
 
 ENV SIA_DIR /sia
 ENV SIA_DATA_DIR="/sia-data"
@@ -22,11 +21,6 @@ RUN apk --no-cache add socat
 WORKDIR "$SIA_DIR"
 COPY --from=builder /go/bin/siad ./
 COPY --from=builder go/bin/siac ./
-
-COPY ../healthcheck.sh .
-
-HEALTHCHECK --interval=10s CMD ["./healthcheck.sh"]
-
 ENTRYPOINT socat tcp-listen:9980,reuseaddr,fork tcp:localhost:8000 & \
   ./siad \
     --modules "$SIA_MODULES" \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -11,6 +11,7 @@ RUN go get -d -u gitlab.com/NebulousLabs/Sia/... && \
 
 FROM alpine
 LABEL maintainer="NebulousLabs <developers@nebulous.tech>"
+LABEL autoheal=true
 
 ENV SIA_DIR /sia
 ENV SIA_DATA_DIR="/sia-data"
@@ -21,6 +22,11 @@ RUN apk --no-cache add socat
 WORKDIR "$SIA_DIR"
 COPY --from=builder /go/bin/siad ./
 COPY --from=builder go/bin/siac ./
+
+COPY ../healthcheck.sh .
+
+HEALTHCHECK --interval=10s CMD ["./healthcheck.sh"]
+
 ENTRYPOINT socat tcp-listen:9980,reuseaddr,fork tcp:localhost:8000 & \
   ./siad \
     --modules "$SIA_MODULES" \

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Check if `socat` is running
-if [[ -z $(pidof socat) ]]; then
+if [ -z "$(pidof socat)" ]; then
   exit 1
 fi
 

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-# Make sure that `pidof` is available
-if [[ -z $(which pidof) ]]; then
-  exit 1
-fi
-
 # Check if `socat` is running
 if [[ -z $(pidof socat) ]]; then
   exit 1

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Make sure that `pidof` is available
+if [[ -z $(which pidof) ]]; then
+  exit 1
+fi
+
+# Check if `socat` is running
+if [[ -z $(pidof socat) ]]; then
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This PR introduces a [HEALTHCHECK](https://docs.docker.com/engine/reference/builder/#healthcheck) command and an `autoheal` label.

The healthcheck script is executed every 10 seconds and verifies that the `socat` relay is still up. If it's not it marks the container as "unhealthy".

Marking a container as "unhealthy" doesn't do anything on its own, aside from triggering a `health_status` event. It does, however, allows the user to handle the situation within their system (e.g. Kubernetes can monitor the health of the containers it's running). A simple way to achieve that is by using the [willfarrell/autoheal](https://hub.docker.com/r/willfarrell/autoheal/) container that can monitor and restart any unhealthy container that's labelled with `autoheal`.

Fixes #3 