### PR TITLE
Build the lastest *successful* `master`.

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -4,8 +4,13 @@ LABEL maintainer="NebulousLabs <devs@nebulous.tech>"
 ENV GOOS linux
 ENV GOARCH amd64
 
-RUN go get -d -u gitlab.com/NebulousLabs/Sia/... && \
+# Fetches the sha of the latest commit on the master branch that passed CI.
+COPY dev/master_sha.go .
+
+RUN export SHA=`go run master_sha.go` && \
+    go get -d -u gitlab.com/NebulousLabs/Sia/... && \
     cd $GOPATH/src/gitlab.com/NebulousLabs/Sia && \
+    git reset --hard $SHA && \
     make release
 
 FROM alpine:3

--- a/dev/master_sha.go
+++ b/dev/master_sha.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+)
+
+type build struct {
+	Sha    string `json:"sha"`
+	Status string `json:"status"` // either "failed" or "success"
+}
+
+func main() {
+	resp, err := http.Get("https://gitlab.com/api/v4/projects/7508674/pipelines?ref=master&scope=finished&order_by=updated_at&sort=desc")
+	if err != nil || resp.StatusCode > 299 {
+		fmt.Println("Failed to fetch pipelines status.", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("Failed to read GitLab's response.", err)
+		os.Exit(1)
+	}
+	var builds []build
+	err = json.Unmarshal(body, &builds)
+	if err != nil {
+		fmt.Println("Failed to parse pipelines status.", err)
+		os.Exit(1)
+	}
+	// Get the first successful build. They are already sorted by update time,
+	// so the first we find will be the most recent one.
+	for _, b := range builds {
+		if b.Status == "success" {
+			fmt.Println(b.Sha)
+			os.Exit(0)
+		}
+	}
+	fmt.Println("No successful builds found.")
+	os.Exit(1)
+}


### PR DESCRIPTION
When building the `dev` image we fetch and build the latest `master` branch. This is not ideal because the branch might be broken at the moment. It's much better to build the latest `master` that passed its CI build. In that case we know that we're building something that's at least usable, if not stable (we can't guarantee stability outside of releases).

What this MR does:
1. query Sia's pipelines via GitLab's API
2. fetch the SHA of the latest commit that passed its CI build
3. get the latest Sia
4. `git reset --hard` to the good SHA we fetched in step 1