### PR TITLE
Add suport for Raspberry Pi

### DIFF
--- a/build
+++ b/build
@@ -16,7 +16,7 @@ cleanup_test_containers() {
 
 cleanup_test_containers
 
-for DIR in ./ ./alpine ./dev
+for DIR in ./ ./alpine ./dev ./pi
 do
   docker build \
     --tag sia-image \

--- a/pi/Dockerfile
+++ b/pi/Dockerfile
@@ -1,0 +1,39 @@
+FROM debian:stretch-slim AS zip_downloader
+LABEL maintainer="NebulousLabs <devs@nebulous.tech>"
+
+ARG SIA_VERSION="1.4.7"
+ARG SIA_PACKAGE="Sia-v${SIA_VERSION}-linux-arm64"
+ARG SIA_ZIP="${SIA_PACKAGE}.zip"
+ARG SIA_RELEASE="https://sia.tech/releases/${SIA_ZIP}"
+
+RUN apt-get update && \
+    apt-get install -y wget unzip && \
+    wget "$SIA_RELEASE" && \
+    mkdir /sia && \
+    unzip -j "$SIA_ZIP" "${SIA_PACKAGE}/siac" -d /sia && \
+    unzip -j "$SIA_ZIP" "${SIA_PACKAGE}/siad" -d /sia
+
+FROM arm64v8/alpine
+LABEL maintainer="NebulousLabs <devs@nebulous.tech>"
+LABEL autoheal=true
+
+RUN apk add --no-cache socat
+
+ARG SIA_DIR="/sia"
+ARG SIA_DATA_DIR="/sia-data"
+
+WORKDIR "$SIA_DIR"
+
+ENV SIA_DATA_DIR "$SIA_DATA_DIR"
+ENV SIA_MODULES gctwhr
+
+COPY --from=zip_downloader /sia/siac .
+COPY --from=zip_downloader /sia/siad .
+COPY scripts/healthcheck.sh .
+COPY scripts/run.sh .
+
+EXPOSE 9980 9981 9982
+
+HEALTHCHECK --interval=10s CMD ["./healthcheck.sh"]
+
+ENTRYPOINT ["./run.sh"]

--- a/pi/Dockerfile
+++ b/pi/Dockerfile
@@ -17,10 +17,15 @@ FROM arm64v8/alpine
 LABEL maintainer="NebulousLabs <devs@nebulous.tech>"
 LABEL autoheal=true
 
-RUN apk add --no-cache socat
-
 ARG SIA_DIR="/sia"
 ARG SIA_DATA_DIR="/sia-data"
+
+RUN apk add --no-cache socat
+
+# Workaround for backwards compatibility with old images, which hardcoded the
+# Sia data directory as /mnt/sia. Creates a symbolic link so that any previous
+# path references stored in the Sia host config still work.
+RUN ln -s "$SIA_DATA_DIR" /mnt/sia
 
 WORKDIR "$SIA_DIR"
 


### PR DESCRIPTION
This MR adds a Raspberry Pi (ARMv8) image.

ARMv8 support covers Raspberry Pi 3 and 4 and coincides with the ARM binaries we've been providing so far.

This image does **not** support older/smaller Pis such as Pi 1, Pi 2, Pi Zero - those are small and underpowered machines that will have trouble running `siad`.

This MR build on top of #17 

Part of https://github.com/NebulousLabs/docker-sia/issues/12