### PR TITLE
v1.4.10 + Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim AS zip_downloader
 LABEL maintainer="NebulousLabs <devs@nebulous.tech>"
 
-ARG SIA_VERSION="1.4.8"
+ARG SIA_VERSION="1.4.10"
 ARG SIA_PACKAGE="Sia-v${SIA_VERSION}-linux-amd64"
 ARG SIA_ZIP="${SIA_PACKAGE}.zip"
 ARG SIA_RELEASE="https://sia.tech/releases/${SIA_ZIP}"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+name=sia-container
+version=1.4.10
+
+default: release
+
+all: release dev alpine pi
+
+dev:
+	docker build -f dev/Dockerfile \
+		-t $(name) -t nebulouslabs/sia:dev \
+		.
+
+release:
+	docker build -f Dockerfile \
+		--build-arg SIA_VERSION=$(version) \
+		-t $(name) -t nebulouslabs/sia:$(version) -t nebulouslabs/sia:latest \
+		.
+
+alpine:
+	docker build -f alpine/Dockerfile \
+		--build-arg SIA_VERSION=$(version) \
+		-t $(name) -t nebulouslabs/sia:alpine-$(version) -t nebulouslabs/sia:alpine-latest \
+		.
+
+pi:
+	docker build -f pi/Dockerfile \
+		--build-arg SIA_VERSION=$(version) \
+		-t $(name) -t nebulouslabs/sia:pi-$(version) -t nebulouslabs/sia:pi-latest \
+		.
+
+stop:
+	docker stop $(docker ps -a -q --filter "name=$(name)") && docker rm $(docker ps -a -q --filter "name=$(name)")

--- a/README.md
+++ b/README.md
@@ -7,15 +7,18 @@
 ## Supported Tags
 
 * **latest**: The latest official binary release.
+* **1.4.10**
 * **1.4.8**
 * **1.4.7**
 
 * **alpine-latest**: The latest official binary release based on Alpine Linux.
+* **alpine-1.4.10**
 * **alpine-1.4.8**
 * **alpine-1.4.7**
 
 * **pi-latest**: The latest official binary release for Raspberry Pi or any other 
 machine with an ARMv8 CPU.
+* **pi-1.4.10**
 * **pi-1.4.8**
 * **pi-1.4.7**
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim AS zip_downloader
 LABEL maintainer="NebulousLabs <devs@nebulous.tech>"
 
-ARG SIA_VERSION="1.4.8"
+ARG SIA_VERSION="1.4.10"
 ARG SIA_PACKAGE="Sia-v${SIA_VERSION}-linux-amd64"
 ARG SIA_ZIP="${SIA_PACKAGE}.zip"
 ARG SIA_RELEASE="https://sia.tech/releases/${SIA_ZIP}"

--- a/pi/Dockerfile
+++ b/pi/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim AS zip_downloader
 LABEL maintainer="NebulousLabs <devs@nebulous.tech>"
 
-ARG SIA_VERSION="1.4.8"
+ARG SIA_VERSION="1.4.10"
 ARG SIA_PACKAGE="Sia-v${SIA_VERSION}-linux-arm64"
 ARG SIA_ZIP="${SIA_PACKAGE}.zip"
 ARG SIA_RELEASE="https://sia.tech/releases/${SIA_ZIP}"


### PR DESCRIPTION
Update all images to version 1.4.10.

Add a Makefile with some often used commands. This is used for local development at the moment but we can also use it for deployment purposes down the road.