### PR TITLE
Move sia binaries from `/sia` to `/usr/bin`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,8 @@ ENV SIA_DATA_DIR "$SIA_DATA_DIR"
 ENV SIAD_DATA_DIR "$SIAD_DATA_DIR"
 ENV SIA_MODULES gctwhr
 
-COPY --from=zip_downloader /sia/siac .
-COPY --from=zip_downloader /sia/siad .
-COPY scripts/healthcheck.sh .
-COPY scripts/run.sh .
+COPY --from=zip_downloader /sia/siac /sia/siad /usr/bin/
+COPY scripts/*.sh ./
 
 EXPOSE 9980 9981 9982
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -36,10 +36,8 @@ ENV SIA_DATA_DIR "$SIA_DATA_DIR"
 ENV SIAD_DATA_DIR "$SIAD_DATA_DIR"
 ENV SIA_MODULES gctwhr
 
-COPY --from=zip_downloader /sia/siac .
-COPY --from=zip_downloader /sia/siad .
-COPY scripts/healthcheck.sh .
-COPY scripts/run.sh .
+COPY --from=zip_downloader /sia/siac /sia/siad /usr/bin/
+COPY scripts/*.sh ./
 
 EXPOSE 9980 9981 9982
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -36,10 +36,8 @@ ENV SIA_DATA_DIR "$SIA_DATA_DIR"
 ENV SIAD_DATA_DIR "$SIAD_DATA_DIR"
 ENV SIA_MODULES gctwhr
 
-COPY --from=builder /go/bin/siac .
-COPY --from=builder /go/bin/siad .
-COPY scripts/healthcheck.sh .
-COPY scripts/run.sh .
+COPY --from=builder /go/bin/siac /go/bin/siad /usr/bin/
+COPY scripts/*.sh ./
 
 EXPOSE 9980 9981 9982
 

--- a/pi/Dockerfile
+++ b/pi/Dockerfile
@@ -40,10 +40,8 @@ ENV SIA_DATA_DIR "$SIA_DATA_DIR"
 ENV SIAD_DATA_DIR "$SIAD_DATA_DIR"
 ENV SIA_MODULES gctwhr
 
-COPY --from=zip_downloader /sia/siac .
-COPY --from=zip_downloader /sia/siad .
-COPY scripts/healthcheck.sh .
-COPY scripts/run.sh .
+COPY --from=zip_downloader /sia/siac /sia/siad /usr/bin/
+COPY scripts/*.sh ./
 
 EXPOSE 9980 9981 9982
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,7 +4,7 @@ socat tcp-listen:9980,reuseaddr,fork tcp:localhost:8000 &
 
 # Use the `cat` utility in order assign a multi-line string to a variable.
 SIAD_CMD=$(cat <<-END
-./siad \
+/usr/bin/siad \
   --modules $SIA_MODULES \
   --sia-directory $SIA_DATA_DIR \
   --api-addr localhost:8000

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,7 +4,7 @@ socat tcp-listen:9980,reuseaddr,fork tcp:localhost:8000 &
 
 # Use the `cat` utility in order assign a multi-line string to a variable.
 SIAD_CMD=$(cat <<-END
-/usr/bin/siad \
+siad \
   --modules $SIA_MODULES \
   --sia-directory $SIA_DATA_DIR \
   --api-addr localhost:8000


### PR DESCRIPTION
Moving the `siac` and `siad` binaries from `/sia` to `/usr/bin`, so they easily accessible on the path. This will help with debugging from outside the container (with `docker exec -it`).