### PR TITLE
Add packages that provide OS-level mime-type support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ ARG SIA_DIR="/sia"
 ARG SIA_DATA_DIR="/sia-data"
 ARG SIAD_DATA_DIR="/sia-data"
 
+RUN apt-get update && apt-get install -y mime-support
+
 # Workaround for backwards compatibility with old images, which hardcoded the
 # Sia data directory as /mnt/sia. Creates a symbolic link so that any previous
 # path references stored in the Sia host config still work.

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -20,8 +20,10 @@ ARG SIA_DIR="/sia"
 ARG SIA_DATA_DIR="/sia-data"
 ARG SIAD_DATA_DIR="/sia-data"
 
+# We need the mailcap package for the mime types support it provides.
 RUN mkdir /lib64 && \
-    ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+    ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 && \
+    apk add mailcap
 
 # Workaround for backwards compatibility with old images, which hardcoded the
 # Sia data directory as /mnt/sia. Creates a symbolic link so that any previous

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -23,8 +23,10 @@ ARG SIA_DIR="/sia"
 ARG SIA_DATA_DIR="/sia-data"
 ARG SIAD_DATA_DIR="/sia-data"
 
+# We need the mailcap package for the mime types support it provides.
 RUN mkdir /lib64 && \
-    ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+    ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 && \
+    apk add mailcap
 
 # Workaround for backwards compatibility with old images, which hardcoded the
 # Sia data directory as /mnt/sia. Creates a symbolic link so that any previous

--- a/pi/Dockerfile
+++ b/pi/Dockerfile
@@ -23,6 +23,8 @@ ARG SIA_DIR="/sia"
 ARG SIA_DATA_DIR="/sia-data"
 ARG SIAD_DATA_DIR="/sia-data"
 
+RUN apt-get update && apt-get install -y mime-support
+
 # We need qemu in order to run ARM commands on an AMD64 CI machine.
 COPY --from=zip_downloader qemu-aarch64-static /usr/bin
 


### PR DESCRIPTION
These changes ensure that we'll have the `/etc/mime.types` files installed in the container, making content type detection possible and reliable.

On Debian we use the `mime-support` package and on Alpine we use `mailcap` because these are the packages which provide the needed file.