### PR TITLE
Fix the mime support on Raspberry Pi.

### DIFF
--- a/pi/Dockerfile
+++ b/pi/Dockerfile
@@ -23,10 +23,10 @@ ARG SIA_DIR="/sia"
 ARG SIA_DATA_DIR="/sia-data"
 ARG SIAD_DATA_DIR="/sia-data"
 
-RUN apt-get update && apt-get install -y mime-support
-
 # We need qemu in order to run ARM commands on an AMD64 CI machine.
 COPY --from=zip_downloader qemu-aarch64-static /usr/bin
+
+RUN apt-get update && apt-get install -y mime-support
 
 # Workaround for backwards compatibility with old images, which hardcoded the
 # Sia data directory as /mnt/sia. Creates a symbolic link so that any previous


### PR DESCRIPTION
We need to load `qemu` before installing any software.