### PR TITLE
Exclude `dev` images from the build check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ docker run \
   --publish 127.0.0.1:9980:9980 \
   --publish 9981:9981 \
   --publish 9982:9982 \
+  --publish 9983:9983 \
+  --publish 9984:9984 \
   --name sia-container \
    nebulouslabs/sia
 ```

--- a/build
+++ b/build
@@ -16,7 +16,7 @@ cleanup_test_containers() {
 
 cleanup_test_containers
 
-for DIR in . ./alpine ./pi ./dev ./dev-debian ./debug
+for DIR in . ./alpine ./pi
 do
   docker build \
     --tag sia-image \


### PR DESCRIPTION
Our `dev` images fail to build because it's been a while since our last successful CI on `master`. While the red CI is a separate problem to tackle, the fact that it hasn't succeeded in so long means that GitLab's API doesn't return any successful builds for it, causing the build of this repo to fail. This is preventing us from delivering new images. That is the problem which this PR is trying to solve - don't let a broken `dev` build stop the delivery of new images.