### PR TITLE
Fix dev images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,13 @@ dev:
 		-t $(name) -t nebulouslabs/sia:dev \
 		.
 
+dev-debian:
+	docker build -f dev-debian/Dockerfile \
+		--build-arg "SHA=$(sha)" \
+		--build-arg "TAG=$(tag)" \
+		-t $(name) -t nebulouslabs/sia:dev-debian \
+		.
+
 debug:
 	docker build -f debug/Dockerfile -t $(name) -t nebulouslabs/sia:debug .
 
@@ -39,4 +46,4 @@ ci:
 stop:
 	docker stop $(docker ps -a -q --filter "name=$(name)") && docker rm $(docker ps -a -q --filter "name=$(name)")
 
-.PHONY: all default release alpine pi dev debug ci stop
+.PHONY: all default release alpine pi dev debug ci stop dev-debian

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.15
 LABEL maintainer="NebulousLabs <devs@nebulous.tech>"
 
+ENV GO111MODULE on
+
 RUN apt-get update && \
     apt-get -y install python3-pip && \
     apt-get clean && \

--- a/debug/Dockerfile
+++ b/debug/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="NebulousLabs <devs@nebulous.tech>"
 
 ENV GOOS linux
 ENV GOARCH amd64
+ENV GO111MODULE on
 
 WORKDIR /root
 
@@ -14,12 +15,11 @@ RUN apt-get update && \
     mv /etc/cron.daily/logrotate /etc/cron.hourly && \
     wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.30.0 && \
     pip3 install codespell && \
-    go get -d -u gitlab.com/NebulousLabs/Sia/... && \
     go get gitlab.com/NebulousLabs/analyze && \
-    ln -s $GOPATH/src/gitlab.com/NebulousLabs/Sia ./ && \
-    cd $GOPATH/src/gitlab.com/NebulousLabs/Sia && \
+    git clone https://gitlab.com/NebulousLabs/Sia.git && \
+    cd Sia && \
     make release && \
-    cd
+    cd -
 
 # Setup the actual Sia environment.
 ARG SIA_DIR="/sia"

--- a/dev-debian/Dockerfile
+++ b/dev-debian/Dockerfile
@@ -3,16 +3,19 @@ LABEL maintainer="NebulousLabs <devs@nebulous.tech>"
 
 ENV GOOS linux
 ENV GOARCH amd64
+ENV GO111MODULE on
 
 ARG SHA
 ARG TAG
 
 # Fetches the sha of the latest commit on the master branch that passed CI.
+# This is overriden by the manually supplied TAG and SHA values. That's done
+# in the Go code.
 COPY scripts/master_sha.go .
 
-RUN export SHA=`go run master_sha.go` && \
-    go get -d -u gitlab.com/NebulousLabs/Sia/... && \
-    cd $GOPATH/src/gitlab.com/NebulousLabs/Sia && \
+RUN SHA=`go run master_sha.go` && \
+    git clone https://gitlab.com/NebulousLabs/Sia.git && \
+    cd Sia && \
     git reset --hard $SHA && \
     make release
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -3,16 +3,19 @@ LABEL maintainer="NebulousLabs <devs@nebulous.tech>"
 
 ENV GOOS linux
 ENV GOARCH amd64
+ENV GO111MODULE on
 
 ARG SHA
 ARG TAG
 
 # Fetches the sha of the latest commit on the master branch that passed CI.
+# This is overriden by the manually supplied TAG and SHA values. That's done
+# in the Go code.
 COPY scripts/master_sha.go .
 
-RUN export SHA=`go run master_sha.go` && \
-    go get -d -u gitlab.com/NebulousLabs/Sia/... && \
-    cd $GOPATH/src/gitlab.com/NebulousLabs/Sia && \
+RUN SHA=`go run master_sha.go` && \
+    git clone https://gitlab.com/NebulousLabs/Sia.git && \
+    cd Sia && \
     git reset --hard $SHA && \
     make release
 


### PR DESCRIPTION
This PR fixes two problems with building our dev images:
1. The build process failed because go failed to detect that it should be using go modules.
  - Fixed by explicitly exporting `GO111MODULE=on`.
2. The build process failed because `go get -u -d gitlab.com/NebulousLabs/Sia/...` would no longer download the source code under `$GOHOME/src/`.
  - Fixed by switching to `git clone`.