### PR TITLE
Stop logrotate complaining about missing logs

### DIFF
--- a/scripts/logrotate-sia
+++ b/scripts/logrotate-sia
@@ -4,4 +4,5 @@
     compress
     dateext
     copytruncate
+    missingok
 }


### PR DESCRIPTION
On my system, `/sia-data/*.log` doesn't exist. Not sure if that's true everywhere. Anyway, because of this, `exim` tries to send mail about the failure generated by logrotate because it couldn't find those logs, and then for some reason it becomes a zombie process.

After a few days I get 80 or so of these things, obviously one per hour, until I restart the container.

This fixes that.